### PR TITLE
Fix/likes list view img

### DIFF
--- a/DishMatch/Model/Likes/LikesListImageLoader.swift
+++ b/DishMatch/Model/Likes/LikesListImageLoader.swift
@@ -1,0 +1,39 @@
+//
+//  LikesListImageLoader.swift
+//  DishMatch
+//
+//  Created by 大江悠都 on 2025/02/14.
+//
+import SwiftUI
+
+@MainActor
+class ImageLoader: ObservableObject {
+    @Published var image: UIImage? = nil
+    private var retryCount = 0
+    private let maxRetryCount = 3
+
+    func loadImage(from urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+
+        Task {
+            do {
+                let (data, response) = try await URLSession.shared.data(from: url)
+
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
+                   let image = UIImage(data: data) {
+                    self.image = image
+                } else {
+                    throw URLError(.badServerResponse)
+                }
+            } catch {
+                print("⚠️ 画像取得失敗: \(error.localizedDescription)")
+                if self.retryCount < self.maxRetryCount {
+                    self.retryCount += 1
+                    self.loadImage(from: urlString)
+                } else {
+                    print("❌ 画像取得に失敗しました")
+                }
+            }
+        }
+    }
+}

--- a/DishMatch/Model/Likes/LikesListImageLoader.swift
+++ b/DishMatch/Model/Likes/LikesListImageLoader.swift
@@ -9,16 +9,20 @@ import SwiftUI
 @MainActor
 class ImageLoader: ObservableObject {
     @Published var image: UIImage? = nil
+    @Published var isLoading = false
     private var retryCount = 0
     private let maxRetryCount = 3
 
+    /// 指定されたURLから画像を非同期取得するメソッド
+    /// - Parameter urlString: 画像のURL（文字列）
     func loadImage(from urlString: String) {
-        guard let url = URL(string: urlString) else { return }
+        guard let url = URL(string: urlString), !isLoading else { return }
+        isLoading = true
 
         Task {
             do {
                 let (data, response) = try await URLSession.shared.data(from: url)
-
+                
                 if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200,
                    let image = UIImage(data: data) {
                     self.image = image
@@ -27,13 +31,16 @@ class ImageLoader: ObservableObject {
                 }
             } catch {
                 print("⚠️ 画像取得失敗: \(error.localizedDescription)")
-                if self.retryCount < self.maxRetryCount {
-                    self.retryCount += 1
-                    self.loadImage(from: urlString)
+                if retryCount < maxRetryCount {
+                    retryCount += 1
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                        self.loadImage(from: urlString)
+                    }
                 } else {
                     print("❌ 画像取得に失敗しました")
                 }
             }
+            isLoading = false
         }
     }
 }

--- a/DishMatch/Views/Likes/LikeShopsListView.swift
+++ b/DishMatch/Views/Likes/LikeShopsListView.swift
@@ -28,13 +28,13 @@ struct LikeShopsListView: View {
                         .padding()
                 } else {
                     LazyVStack(spacing: 16) {
-                        ForEach(displayedShops.indices, id: \.self) { index in
-                            let shop = displayedShops[index]
+                        ForEach(displayedShops, id: \.id) { shop in
                             HStack(alignment: .top, spacing: 16) {
                                 LikeShopRow(shop: shop)
                             }
                         }
                     }
+
                     .padding()
                 }
             }


### PR DESCRIPTION
タブ切り替え時に店舗画像が更新されない不具合を修正し、AsyncImage の代わりに ImageLoader を導入することで画像の非同期読み込みとキャッシュ管理を適切に行い、LikeShopRow を新設して画像表示の責務を分離することで、タブ切り替え時の画像更新を確実に実行できるようにリファクタリングしました。